### PR TITLE
Make jitsuin-doks wrapper executable

### DIFF
--- a/jitsuin-doks
+++ b/jitsuin-doks
@@ -1,4 +1,5 @@
 E_NOARGS=65
+
 if [ -z "$1" ]
 then
   echo "Usage: `basename $0` target-file"


### PR DESCRIPTION
The README tells people to run `jitsuin-doks start`,which is great, but as committed to the repo it's not executable. That's annoying...

Pointless space added in order to convince git there was a change