### PR TITLE
Commiting API Docs + Fix for OpenAPI shortcode

### DIFF
--- a/config/_default/menus.toml
+++ b/config/_default/menus.toml
@@ -27,6 +27,12 @@
   weight = 60
   identifier = "help"
   url = "/docs/help/"
+  
+[[docs]]
+  name = "API Reference"
+  weight = 50
+  identifier = "api-reference"
+  url = "/docs/api-reference/"
 
 [[docs]]
   name = "User Patterns"

--- a/content/docs/api-reference/_index.md
+++ b/content/docs/api-reference/_index.md
@@ -1,0 +1,13 @@
+---
+title: "Api Reference"
+description: ""
+lead: ""
+date: 2021-06-09T10:19:37+01:00
+lastmod: 2021-06-09T10:19:37+01:00
+draft: false
+images: []
+weight: 999
+toc: false
+---
+
+

--- a/content/docs/api-reference/assets-api/index.md
+++ b/content/docs/api-reference/assets-api/index.md
@@ -1,0 +1,16 @@
+---
+title: "Assets API"
+description: ""
+lead: ""
+date: 2021-06-09T11:39:03+01:00
+lastmod: 2021-06-09T11:39:03+01:00
+draft: false
+images: []
+menu: 
+  docs:
+    parent: "api-reference"
+weight: 101
+toc: true
+---
+
+{{< openapi url="https://raw.githubusercontent.com/jitsuin-inc/archivist-docs/master/doc/openapi/assetsv2.swagger.json" >}}

--- a/content/docs/api-reference/attachments-api/index.md
+++ b/content/docs/api-reference/attachments-api/index.md
@@ -1,0 +1,17 @@
+---
+title: "Attachments API"
+description: ""
+lead: ""
+date: 2021-06-09T12:05:02+01:00
+lastmod: 2021-06-09T12:05:02+01:00
+draft: false
+images: []
+menu: 
+  docs:
+    parent: "api-reference"
+weight: 102
+toc: true
+---
+
+{{< openapi url="https://raw.githubusercontent.com/jitsuin-inc/archivist-docs/master/doc/openapi/attachments.swagger.json" >}}
+

--- a/content/docs/api-reference/blobs-api/index.md
+++ b/content/docs/api-reference/blobs-api/index.md
@@ -1,0 +1,68 @@
+---
+title: "Blobs API"
+description: ""
+lead: ""
+date: 2021-06-09T13:32:57+01:00
+lastmod: 2021-06-09T13:32:57+01:00
+draft: false
+images: []
+menu: 
+  docs:
+    parent: "api-reference"
+weight: 103
+toc: true
+---
+
+## Upload a Blob
+
+Upload the blob stored at /path/to/file:
+
+```bash
+$ curl -v -X POST \
+    -H "@$BEARER_TOKEN_FILE" \
+    -H "content_type=image/jpg" \
+    -F "file=@/path/to/file" \
+    $URL/archivist/v1/blobs
+```
+
+The response is:
+
+```json
+{
+    "identity": "blobs/08838336-c357-460d-902a-3aba9528dd22",
+    "hash": {
+        "alg": "SHA256",
+        "value": "xxxxxxxxxxxxxxxxxxxxxxx"
+    },
+    "mime_type": "image/jpeg",
+    "timestamp_accepted": "2019-11-07T15:31:49Z",
+    "size": 31424
+}
+```
+
+## Retrieve a Blob
+
+Retrieve a specific Attachment
+
+```bash
+$ curl -v \
+    -H "@$BEARER_TOKEN_FILE" \
+    -H "content_type=image/jpg" \
+    -F "file=@/path/to/file" \
+    $URL/archivist/v1/blobs/08838336-c357-460d-902a-3aba9528dd22
+```
+
+The response is:
+
+```json
+{
+    "identity": "blobsV1/08838336-c357-460d-902a-3aba9528dd22",
+    "hash": {
+        "alg": "SHA256",
+        "value": "xxxxxxxxxxxxxxxxxxxxxxx"
+    },
+    "mime_type": "image/jpeg",
+    "timestamp_accepted": "2019-11-07T15:31:49Z",
+    "size": 31424
+}
+```

--- a/content/docs/api-reference/blockchain-api/index.md
+++ b/content/docs/api-reference/blockchain-api/index.md
@@ -1,0 +1,16 @@
+---
+title: "Blockchain API (v1alpha1)"
+description: ""
+lead: ""
+date: 2021-06-09T13:57:04+01:00
+lastmod: 2021-06-09T13:57:04+01:00
+draft: false
+images: []
+menu: 
+  docs:
+    parent: "api-reference"
+weight: 104
+toc: true
+---
+
+{{< openapi url="https://raw.githubusercontent.com/jitsuin-inc/archivist-docs/master/doc/openapi/blockchain_blockchainv1alpha1.swagger.json" >}}

--- a/content/docs/api-reference/compliance-api/index.md
+++ b/content/docs/api-reference/compliance-api/index.md
@@ -1,0 +1,16 @@
+---
+title: "Compliance API"
+description: ""
+lead: ""
+date: 2021-06-09T12:07:13+01:00
+lastmod: 2021-06-09T12:07:13+01:00
+draft: false
+images: []
+menu: 
+  docs:
+    parent: "api-reference"
+weight: 105
+toc: true
+---
+
+{{< openapi url="https://raw.githubusercontent.com/jitsuin-inc/archivist-docs/master/doc/openapi/compliance.swagger.json" >}}

--- a/content/docs/api-reference/events-api/index.md
+++ b/content/docs/api-reference/events-api/index.md
@@ -1,0 +1,38 @@
+---
+title: "Events API"
+description: ""
+lead: ""
+date: 2021-06-09T11:48:40+01:00
+lastmod: 2021-06-09T11:48:40+01:00
+draft: false
+images: []
+menu: 
+  docs:
+    parent: "api-reference"
+weight: 106
+toc: true
+---
+
+## Attachments Example
+
+{{< openapi url="https://raw.githubusercontent.com/jitsuin-inc/archivist-docs/master/doc/openapi/b-attachmentsv2.swagger.json" >}}
+
+## Builtin Operations Example
+
+{{< openapi url="https://raw.githubusercontent.com/jitsuin-inc/archivist-docs/master/doc/openapi/b-builtinv2.swagger.json" >}}
+
+## Firmware Update Example
+
+{{< openapi url="https://raw.githubusercontent.com/jitsuin-inc/archivist-docs/master/doc/openapi/b-firmwarev2.swagger.json" >}}
+
+## Location Update Example
+
+{{< openapi url="https://raw.githubusercontent.com/jitsuin-inc/archivist-docs/master/doc/openapi/b-locationupdatev2.swagger.json" >}}
+
+## Maintenance Example
+
+{{< openapi url="https://raw.githubusercontent.com/jitsuin-inc/archivist-docs/master/doc/openapi/b-maintenancev2.swagger.json" >}}
+
+## Record Evidence Example
+
+{{< openapi url="https://raw.githubusercontent.com/jitsuin-inc/archivist-docs/master/doc/openapi/b-recordevidencev2.swagger.json" >}}

--- a/content/docs/api-reference/groups-api/index.md
+++ b/content/docs/api-reference/groups-api/index.md
@@ -1,0 +1,16 @@
+---
+title: "Groups API"
+description: ""
+lead: ""
+date: 2021-06-09T13:27:37+01:00
+lastmod: 2021-06-09T13:27:37+01:00
+draft: false
+images: []
+menu: 
+  docs:
+    parent: "api-reference"
+weight: 107
+toc: true
+---
+
+{{< openapi url="https://raw.githubusercontent.com/jitsuin-inc/archivist-docs/master/doc/openapi/groups.swagger.json" >}}

--- a/content/docs/api-reference/iam-policies-api/index.md
+++ b/content/docs/api-reference/iam-policies-api/index.md
@@ -1,0 +1,16 @@
+---
+title: "IAM Policies API"
+description: ""
+lead: ""
+date: 2021-06-09T12:02:15+01:00
+lastmod: 2021-06-09T12:02:15+01:00
+draft: false
+images: []
+menu: 
+  docs:
+    parent: "api-reference"
+weight: 107
+toc: true
+---
+
+{{< openapi url="https://raw.githubusercontent.com/jitsuin-inc/archivist-docs/master/doc/openapi/access_policies.swagger.json" >}}

--- a/content/docs/api-reference/locations-api/index.md
+++ b/content/docs/api-reference/locations-api/index.md
@@ -1,0 +1,16 @@
+---
+title: "Locations API"
+description: ""
+lead: ""
+date: 2021-06-09T11:56:23+01:00
+lastmod: 2021-06-09T11:56:23+01:00
+draft: false
+images: []
+menu: 
+  docs:
+    parent: "api-reference"
+weight: 108
+toc: true
+---
+
+{{< openapi url="https://raw.githubusercontent.com/jitsuin-inc/archivist-docs/master/doc/openapi/locationsv2.swagger.json" >}}

--- a/content/docs/api-reference/microsoft-iothub-api/index.md
+++ b/content/docs/api-reference/microsoft-iothub-api/index.md
@@ -1,0 +1,16 @@
+---
+title: "Microsoft IoTHub API"
+description: ""
+lead: ""
+date: 2021-06-09T14:00:29+01:00
+lastmod: 2021-06-09T14:00:29+01:00
+draft: false
+images: []
+menu: 
+  docs:
+    parent: "api-reference"
+weight: 109
+toc: true
+---
+
+{{< openapi url="https://raw.githubusercontent.com/jitsuin-inc/archivist-docs/master/doc/openapi/iothubgdrv2.swagger.json" >}}

--- a/content/docs/api-reference/svc-buses-api/index.md
+++ b/content/docs/api-reference/svc-buses-api/index.md
@@ -1,0 +1,17 @@
+---
+title: "Service Bus API"
+description: ""
+lead: ""
+date: 2021-06-09T14:22:12+01:00
+lastmod: 2021-06-09T14:22:12+01:00
+draft: false
+images: []
+menu: 
+  docs:
+    parent: "api-reference"
+weight: 110
+toc: true
+---
+
+{{< openapi url="https://raw.githubusercontent.com/jitsuin-inc/archivist-docs/master/doc/openapi/svcbussources.swagger.json" >}}
+

--- a/content/docs/api-reference/system-api/index.md
+++ b/content/docs/api-reference/system-api/index.md
@@ -1,0 +1,16 @@
+---
+title: "System API"
+description: ""
+lead: ""
+date: 2021-06-09T13:49:35+01:00
+lastmod: 2021-06-09T13:49:35+01:00
+draft: false
+images: []
+menu: 
+  docs:
+    parent: "api-reference"
+weight: 111
+toc: true
+---
+
+{{< openapi url="https://raw.githubusercontent.com/jitsuin-inc/archivist-docs/master/doc/openapi/archivistnode.swagger.json" >}}

--- a/content/docs/api-reference/tenancies-api/index.md
+++ b/content/docs/api-reference/tenancies-api/index.md
@@ -1,0 +1,16 @@
+---
+title: "Tenancies API"
+description: ""
+lead: ""
+date: 2021-06-09T13:29:57+01:00
+lastmod: 2021-06-09T13:29:57+01:00
+draft: false
+images: []
+menu: 
+  docs:
+    parent: "api-reference"
+weight: 112
+toc: true
+---
+
+{{< openapi url="https://raw.githubusercontent.com/jitsuin-inc/archivist-docs/master/doc/openapi/tenancies.swagger.json" >}}

--- a/content/docs/api-reference/tls-ca-certificates-api/index.md
+++ b/content/docs/api-reference/tls-ca-certificates-api/index.md
@@ -1,0 +1,16 @@
+---
+title: "TLS CA Certificates API"
+description: ""
+lead: ""
+date: 2021-06-09T13:53:24+01:00
+lastmod: 2021-06-09T13:53:24+01:00
+draft: false
+images: []
+menu: 
+  docs:
+    parent: "api-reference"
+weight: 113
+toc: true
+---
+
+{{< openapi url="https://raw.githubusercontent.com/jitsuin-inc/archivist-docs/master/doc/openapi/tlscacertificates.swagger.json" >}}

--- a/layouts/shortcodes/openapi.html
+++ b/layouts/shortcodes/openapi.html
@@ -19,22 +19,22 @@ where fileName is the file's name with `.json` removed from the end
  {{ $.Scratch.Set "id" 0 }}
  {{ with $.Params.url }}
   {{ $openapi := getJSON $.Params.url }}
+  {{ $componentID := index (split $openapi.info.title " API") 0 }}
   <div class="$openapi-spec-content">
-    <h2>{{ $openapi.info.title }} version {{ $openapi.info.version }}</h2>
     <div class="description">
       <p>{{ $openapi.info.description }}</p>
     </div>
-      <div class="accordion" id='{{ $.Scratch.Get "id" }}'></div>
+      <div class="accordion" id='{{ $componentID }}{{ $.Scratch.Get "id" }}'></div>
       {{ range $path, $pathMethods := $openapi.paths }}
         {{ range $pathMethod, $pathDetails := $pathMethods }}
           {{ $.Scratch.Set "id" (add ($.Scratch.Get "id") 1) }}
                 <div class="accordion-item">
-                  <h3 class="accordion-header" id='header{{ $.Scratch.Get "id" }}'>
-                      <button class="accordion-button" data-bs-toggle="collapse" data-bs-target='#collapse{{ $.Scratch.Get "id" }}' aria-expanded="true" aria-controls='collapse{{ $.Scratch.Get "id" }}'>
+                  <h3 class="accordion-header" id='header{{ $componentID }}{{ $.Scratch.Get "id" }}'>
+                      <button class="accordion-button" data-bs-toggle="collapse" data-bs-target='#collapse{{ $componentID }}{{ $.Scratch.Get "id" }}' aria-expanded="true" aria-controls='collapse{{ $componentID }}{{ $.Scratch.Get "id" }}'>
                         <span style="text-transform: uppercase; color: #ed1c24;">{{ $pathMethod }}</span>&nbsp;&nbsp;<span style="width: 100%;">{{ $path }}</span>
                       </button>
                   </h3>
-                  <div id='collapse{{ $.Scratch.Get "id" }}' class="accordion-collapse collapse" aria-labelledby='header{{ $.Scratch.Get "id" }}' data-parent="#accordion">
+                  <div id='collapse{{ $componentID }}{{ $.Scratch.Get "id" }}' class="accordion-collapse collapse" aria-labelledby='header{{ $componentID }}{{ $.Scratch.Get "id" }}' data-parent="#accordion">
                   <div class="accordion-body">
                     <div style="width: 100%;">
                       <h4><span style="color: #ed1c24; text-transform: uppercase;">{{ $pathMethod }}</span>&nbsp;&nbsp;<span>{{ $path }}</span></h4>
@@ -50,12 +50,12 @@ where fileName is the file's name with `.json` removed from the end
                             {{ $parameterComponent := (split $parameterReference "#/definitions/") }}
                             {{ $parameterExample := index $openapi.definitions (index $parameterComponent 1)  }}
                             <div class="accordion-item">
-                              <h3 class="accordion-header" id='headerrequest{{ $.Scratch.Get "id" }}'>
-                                  <button class="accordion-button" data-bs-toggle="collapse" data-bs-target='#collapserequest{{ $.Scratch.Get "id" }}' aria-expanded="true" aria-controls='collapserequest{{ $.Scratch.Get "id" }}'>
+                              <h3 class="accordion-header" id='headerrequest{{ $componentID }}{{ $.Scratch.Get "id" }}'>
+                                  <button class="accordion-button" data-bs-toggle="collapse" data-bs-target='#collapserequest{{ $componentID }}{{ $.Scratch.Get "id" }}' aria-expanded="true" aria-controls='collapserequest{{ $componentID }}{{ $.Scratch.Get "id" }}'>
                                     <span>Example Request</span>
                                   </button>
                               </h3>
-                              <div id='collapserequest{{ $.Scratch.Get "id" }}' class="accordion-collapse collapse" aria-labelledby='headerrequest{{ $.Scratch.Get "id" }}' data-parent="#accordion">
+                              <div id='collapserequest{{ $componentID }}{{ $.Scratch.Get "id" }}' class="accordion-collapse collapse" aria-labelledby='headerrequest{{ $componentID }}{{ $.Scratch.Get "id" }}' data-parent="#accordion">
                                 <div class="accordion-body">
                                   <div style="width: 100%;">
                                     <pre><code>{{$parameterExample.example | jsonify (dict "indent" "  ") }}</code></pre>
@@ -118,12 +118,12 @@ where fileName is the file's name with `.json` removed from the end
                             {{ $component := (split $example "#/definitions/") }}
                             {{ $responseExample := index $openapi.definitions (index $component 1)  }}
                             <div class="accordion-item">
-                              <h3 class="accordion-header" id='headerresponse{{ $.Scratch.Get "id" }}'>
-                                  <button class="accordion-button" data-bs-toggle="collapse" data-bs-target='#collapseresponse{{ $.Scratch.Get "id" }}' aria-expanded="true" aria-controls='collapserequest{{ $.Scratch.Get "id" }}'>
+                              <h3 class="accordion-header" id='headerresponse{{ $componentID }}{{ $.Scratch.Get "id" }}'>
+                                  <button class="accordion-button" data-bs-toggle="collapse" data-bs-target='#collapseresponse{{ $componentID }}{{ $.Scratch.Get "id" }}' aria-expanded="true" aria-controls='collapserequest{{ $componentID }}{{ $.Scratch.Get "id" }}'>
                                     <span>Example Response</span>
                                   </button>
                               </h3>
-                              <div id='collapseresponse{{ $.Scratch.Get "id" }}' class="accordion-collapse collapse" aria-labelledby='headerresponse{{ $.Scratch.Get "id" }}' data-parent="#accordion">
+                              <div id='collapseresponse{{ $componentID }}{{ $.Scratch.Get "id" }}' class="accordion-collapse collapse" aria-labelledby='headerresponse{{ $componentID }}{{ $.Scratch.Get "id" }}' data-parent="#accordion">
                                 <div class="accordion-body">
                                   <div style="width: 100%;">
                                     <pre><code>{{$responseExample.example | jsonify (dict "indent" "  ") }}</code></pre>
@@ -182,4 +182,4 @@ where fileName is the file's name with `.json` removed from the end
     {{ end }}
 
   </div>
-</div>
+


### PR DESCRIPTION
Adding the underlying references to the OpenAPI docs which should then pull in info from our existing docs automatically

Also fixing an issue in how whole accordion items were being labelled with similar tags so that when multiple were on a page they would end up interacting with eachother

Now I strip " API" from the title of the document and then insert that in as an identifier to make each accordion unique - this does cause an issue with the System API document but that does not follow the conventional title (it has a space between "Archivist Node") and should be amended like the other swagger files to "ArchivistNode" (see "MicrosoftIoTHub")

I also fixed an errant `</div>` which was causing layout issues with other components