### PR TITLE
Fixing overflowing endpoints when text is too long

### DIFF
--- a/content/contributing/playground/openapi-example-render/index.md
+++ b/content/contributing/playground/openapi-example-render/index.md
@@ -13,5 +13,6 @@ weight: 999
 toc: true
 ---
 
-{{< openapi url="https://raw.githubusercontent.com/jitsuin-inc/archivist-docs/master/doc/openapi/access_policies.swagger.json" >}}
+{{< openapi url="https://raw.githubusercontent.com/honourfish/test/main/test2.json" >}}
+
 

--- a/content/contributing/playground/openapi-example-render/index.md
+++ b/content/contributing/playground/openapi-example-render/index.md
@@ -13,6 +13,4 @@ weight: 999
 toc: true
 ---
 
-{{< openapi url="https://raw.githubusercontent.com/honourfish/test/main/test2.json" >}}
-
-
+{{< openapi url="https://raw.githubusercontent.com/jitsuin-inc/archivist-docs/master/doc/openapi/access_policies.swagger.json" >}}

--- a/layouts/shortcodes/openapi.html
+++ b/layouts/shortcodes/openapi.html
@@ -31,13 +31,17 @@ where fileName is the file's name with `.json` removed from the end
                 <div class="accordion-item">
                   <h3 class="accordion-header" id='header{{ $componentID }}{{ $.Scratch.Get "id" }}'>
                       <button class="accordion-button" data-bs-toggle="collapse" data-bs-target='#collapse{{ $componentID }}{{ $.Scratch.Get "id" }}' aria-expanded="true" aria-controls='collapse{{ $componentID }}{{ $.Scratch.Get "id" }}'>
-                        <span style="text-transform: uppercase; color: #ed1c24;">{{ $pathMethod }}</span>&nbsp;&nbsp;<span style="width: 100%;">{{ $path }}</span>
+                        <div class="overflow-hidden text-nowrap">
+                          <span style="text-transform: uppercase; color: #ed1c24;">{{ $pathMethod }}</span>&nbsp;&nbsp;<span style="width: 100%; overflow-wrap: break-word;">{{ $path }}</span>
+                        </div>
                       </button>
                   </h3>
                   <div id='collapse{{ $componentID }}{{ $.Scratch.Get "id" }}' class="accordion-collapse collapse" aria-labelledby='header{{ $componentID }}{{ $.Scratch.Get "id" }}' data-parent="#accordion">
                   <div class="accordion-body">
                     <div style="width: 100%;">
+                      <div class="overflow-auto">
                       <h4><span style="color: #ed1c24; text-transform: uppercase;">{{ $pathMethod }}</span>&nbsp;&nbsp;<span>{{ $path }}</span></h4>
+                      </div>
                       <h5>{{ $pathDetails.summary }}</h5>
                       <p><a href="{{ $pathDetails.externalDocs.url }}">{{ $pathDetails.externalDocs.description}}</a></p>
                       <p>Description: {{ $pathDetails.description | markdownify }}</p>


### PR DESCRIPTION
There was an issue that with some of the newer openapi specs that longer endpoints would be poorly rendered and spill over

This fixes the behaviour by creating overflow divs around the button text and the title, the button text becomes unscrollable but no longer overspills, when you expand the title you then have the full one which scrolls