### PR TITLE
Updated swagger references

### DIFF
--- a/content/contributing/playground/openapi-example-render/index.md
+++ b/content/contributing/playground/openapi-example-render/index.md
@@ -13,4 +13,4 @@ weight: 999
 toc: true
 ---
 
-{{< openapi url="https://raw.githubusercontent.com/jitsuin-inc/archivist-docs/master/doc/openapi/access_policies.swagger.json" >}}
+{{< openapi url="https://raw.githubusercontent.com/jitsuin-inc/archivist-docs/master/doc/openapi/subjectsv1.swagger.json" >}}

--- a/content/docs/api-reference/attachments-api/index.md
+++ b/content/docs/api-reference/attachments-api/index.md
@@ -68,5 +68,5 @@ The response will include basic information about the attachment:
 
 ## Attachment OpenAPI Docs
 
-{{< openapi url="https://raw.githubusercontent.com/jitsuin-inc/archivist-docs/master/doc/openapi/attachments.swagger.json" >}}
+{{< openapi url="https://raw.githubusercontent.com/jitsuin-inc/archivist-docs/master/doc/openapi/attachmentsv1.swagger.json" >}}
 

--- a/content/docs/api-reference/blobs-api/index.md
+++ b/content/docs/api-reference/blobs-api/index.md
@@ -76,3 +76,7 @@ The response is:
     "size": 31424
 }
 ```
+
+## Blobs OpenAPI Docs
+
+{{< openapi url="https://raw.githubusercontent.com/jitsuin-inc/archivist-docs/master/doc/openapi/blobsv1.swagger.json" >}}

--- a/content/docs/api-reference/blockchain-api/index.md
+++ b/content/docs/api-reference/blockchain-api/index.md
@@ -82,4 +82,4 @@ Each of these calls returns a list of matching blockchain transactions in the fo
 
 ## Blockchain OpenAPI Docs
 
-{{< openapi url="https://raw.githubusercontent.com/jitsuin-inc/archivist-docs/master/doc/openapi/blockchain_blockchainv1alpha1.swagger.json" >}}
+{{< openapi url="https://raw.githubusercontent.com/jitsuin-inc/archivist-docs/master/doc/openapi/blockchainv1alpha1.swagger.json" >}}

--- a/content/docs/api-reference/compliance-api/index.md
+++ b/content/docs/api-reference/compliance-api/index.md
@@ -256,4 +256,4 @@ The response is:
 
 ## Compliance OpenAPI Docs
 
-{{< openapi url="https://raw.githubusercontent.com/jitsuin-inc/archivist-docs/master/doc/openapi/compliance.swagger.json" >}}
+{{< openapi url="https://raw.githubusercontent.com/jitsuin-inc/archivist-docs/master/doc/openapi/compliancev1.swagger.json" >}}

--- a/content/docs/api-reference/iam-policies-api/index.md
+++ b/content/docs/api-reference/iam-policies-api/index.md
@@ -452,4 +452,4 @@ Each of these calls returns a list of matching IAM `access_policies` records in 
 
 ## IAM Policies OpenAPI Docs
 
-{{< openapi url="https://raw.githubusercontent.com/jitsuin-inc/archivist-docs/master/doc/openapi/access_policiesv1.swagger.json" >}}
+{{< openapi url="https://raw.githubusercontent.com/jitsuin-inc/archivist-docs/master/doc/openapi/accesspoliciesv1.swagger.json" >}}

--- a/content/docs/api-reference/iam-policies-api/index.md
+++ b/content/docs/api-reference/iam-policies-api/index.md
@@ -452,4 +452,4 @@ Each of these calls returns a list of matching IAM `access_policies` records in 
 
 ## IAM Policies OpenAPI Docs
 
-{{< openapi url="https://raw.githubusercontent.com/jitsuin-inc/archivist-docs/master/doc/openapi/access_policies.swagger.json" >}}
+{{< openapi url="https://raw.githubusercontent.com/jitsuin-inc/archivist-docs/master/doc/openapi/access_policiesv1.swagger.json" >}}

--- a/content/docs/api-reference/iam-subjects-api/index.md
+++ b/content/docs/api-reference/iam-subjects-api/index.md
@@ -202,4 +202,4 @@ The response is:
 
 ## IAM Subjects OpenAPI Docs
 
-{{< openapi url="https://raw.githubusercontent.com/jitsuin-inc/archivist-docs/master/doc/openapi/subjects.swagger.json" >}}
+{{< openapi url="https://raw.githubusercontent.com/jitsuin-inc/archivist-docs/master/doc/openapi/subjectsv1.swagger.json" >}}

--- a/content/docs/api-reference/svc-buses-api/index.md
+++ b/content/docs/api-reference/svc-buses-api/index.md
@@ -89,4 +89,4 @@ The response is:
 
 ## Service Bus OpenAPI Docs
 
-{{< openapi url="https://raw.githubusercontent.com/jitsuin-inc/archivist-docs/master/doc/openapi/svcbussources.swagger.json" >}}
+{{< openapi url="https://raw.githubusercontent.com/jitsuin-inc/archivist-docs/master/doc/openapi/svcbussourcesv1.swagger.json" >}}

--- a/content/docs/api-reference/system-api/index.md
+++ b/content/docs/api-reference/system-api/index.md
@@ -86,4 +86,4 @@ The response is:
 
 ## System OpenAPI Docs
 
-{{< openapi url="https://raw.githubusercontent.com/jitsuin-inc/archivist-docs/master/doc/openapi/archivistnode.swagger.json" >}}
+{{< openapi url="https://raw.githubusercontent.com/jitsuin-inc/archivist-docs/master/doc/openapi/archivistnodev1.swagger.json" >}}

--- a/content/docs/api-reference/tenancies-api/index.md
+++ b/content/docs/api-reference/tenancies-api/index.md
@@ -68,4 +68,4 @@ curl -v -X PATCH \
 
 ## Tenancies OpenAPI Docs
 
-{{< openapi url="https://raw.githubusercontent.com/jitsuin-inc/archivist-docs/master/doc/openapi/tenancies.swagger.json" >}}
+{{< openapi url="https://raw.githubusercontent.com/jitsuin-inc/archivist-docs/master/doc/openapi/tenanciesv1.swagger.json" >}}

--- a/content/docs/api-reference/tls-ca-certificates-api/index.md
+++ b/content/docs/api-reference/tls-ca-certificates-api/index.md
@@ -168,4 +168,4 @@ The response is (certificate field shortened for brevity):
 
 ## TLS CA Certificates OpenAPI Docs
 
-{{< openapi url="https://raw.githubusercontent.com/jitsuin-inc/archivist-docs/master/doc/openapi/tlscacertificates.swagger.json" >}}
+{{< openapi url="https://raw.githubusercontent.com/jitsuin-inc/archivist-docs/master/doc/openapi/tlscacertificatesv1.swagger.json" >}}


### PR DESCRIPTION
Prep for new swaggers being pushed

All references should have a {{endpoint}}{{version}}.swagger.json format

This is expected to fail until the new swaggers are made available