### PR TITLE
Markdownify fix for poorly rendered tabs content

### DIFF
--- a/layouts/shortcodes/tabs.html
+++ b/layouts/shortcodes/tabs.html
@@ -24,7 +24,7 @@
 {{ else }}
   <div id="{{ $id }}" class="tab-pane fade" role="tabpanel" aria-labelledby="{{ $id }}">
 {{ end }}
-	{{- with .content -}}
+	{{- with .content | markdownify -}}
 		{{- . -}}
 	{{- else -}}
 		{{- if eq $.Page.BundleType "leaf" -}}


### PR DESCRIPTION
Writing non-codelang text in tabs would not render correctly; this puts hugo's smart-ish mardownifying filter in front to catch text that needs to render correctly