### PR TITLE
Adding Public Assets to API Reference

### DIFF
--- a/content/docs/api-reference/assets-api/index.md
+++ b/content/docs/api-reference/assets-api/index.md
@@ -192,6 +192,8 @@ Returns all assets which do not have `arc_display_name` or in which `arc_display
 
 #### Fetch a Public Asset's URL
 
+Fetch the Public URL of a Public Asset
+
 ```bash
 curl -g -v -X GET \
      -H "@$BEARER_TOKEN_FILE" \
@@ -205,6 +207,8 @@ curl -g -v -X GET \
 ```
 
 #### Fetch a Public Asset's Event URL
+
+Fetch the Public URL of an Event on a Public Asset
 
 ```bash
 curl -g -v -X GET \

--- a/content/docs/api-reference/assets-api/index.md
+++ b/content/docs/api-reference/assets-api/index.md
@@ -192,8 +192,32 @@ Returns all assets which do not have `arc_display_name` or in which `arc_display
 
 #### Fetch a Public Asset's URL
 
+```bash
+curl -g -v -X GET \
+     -H "@$BEARER_TOKEN_FILE" \
+     https://app.rkvst.io/archivist/v2/assets/86b61c4b-030e-4c07-9400-463612e6cee4:publicurl
+```
+
+```json
+{
+  "publicurl":"https://app.rkvst.io/archivist/publicassets/86b61c4b-030e-4c07-9400-463612e6cee4"
+}
+```
 
 #### Fetch a Public Asset's Event URL
+
+```bash
+curl -g -v -X GET \
+     -H "@$BEARER_TOKEN_FILE" \
+     https://app.rkvst.io/archivist/v2/assets/86b61c4b-030e-4c07-9400-463612e6cee4/events/7da272ad-19d5-4106-b4af-2980a84c2721:publicurl
+```
+
+```json
+{
+  "publicurl":"https://app.rkvst.io/archivist/publicassets/86b61c4b-030e-4c07-9400-463612e6cee4/events/7da272ad-19d5-4106-b4af-2980a84c2721"
+}
+```
+
 
 ## Asset OpenAPI Docs
 

--- a/content/docs/api-reference/assets-api/index.md
+++ b/content/docs/api-reference/assets-api/index.md
@@ -23,24 +23,24 @@ Define the asset parameters and store in `/path/to/jsonfile`:
 
 ```json
 {
-    "behaviours": ["RecordEvidence", "Attachments"],
-    "attributes": {
-        "arc_firmware_version": "1.0",
-        "arc_serial_number": "vtl-x4-07",
-        "arc_display_name": "tcl.ppj.003",
-        "arc_description": "Traffic flow control light at A603 North East",
-        "arc_home_location_identity": "locations/115340cf-f39e-4d43-a2ee-8017d672c6c6",
-        "arc_display_type": "Traffic light with violation camera",
-        "some_custom_attribute": "value",
-        "arc_attachments": [
-            {
-                "arc_display_name": "arc_primary_image",
-                "arc_attachment_identity": "blobs/87b1a84c-1c6f-442b-923e-a97516f4d275",
-                "arc_hash_alg": "SHA256",
-                "arc_hash_value": "246c316e2cd6971ce5c83a3e61f9880fa6e2f14ae2976ee03500eb282fd03a60"
-            }
-        ]
-    }
+  "attributes": {
+    "arc_attachments": [
+      {
+        "arc_attachment_identity": "blobs/1754b920-cf20-4d7e-9d36-9ed7d479744d",
+        "arc_display_name": "Picture from yesterday",
+        "arc_hash_alg": "sha256",
+        "arc_hash_value": "01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b"
+      }
+    ],
+    "arc_firmware_version": "3.2.1",
+    "arc_home_location_identity": "locations/42054f10-9952-4c10-a082-9fd0d10295ae"
+  },
+  "behaviours": [
+    "RecordEvidence",
+    "Attachments"
+  ],
+  "proof_mechanism": "SIMPLE_HASH",
+  "public": false
 }
 ```
 
@@ -58,33 +58,52 @@ The response is:
 
 ```json
 {
-    "identity": "assets/3f5be24f-fd1b-40e2-af35-ec7c14c74d53",
-    "behaviours": [
-        "RecordEvidence",
-        "Attachments"
+  "at_time": "2019-11-27T14:44:19Z",
+  "attributes": {
+    "arc_attachments": [
+      {
+        "arc_attachment_identity": "blobs/1754b920-cf20-4d7e-9d36-9ed7d479744d",
+        "arc_display_name": "Picture from yesterday",
+        "arc_hash_alg": "sha256",
+        "arc_hash_value": "01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b"
+      }
     ],
-    "attributes": {
-        "arc_serial_number": "vtl-x4-07",
-        "arc_display_name": "tcl.ppj.003",
-        "arc_description": "Traffic flow control light at A603 North East",
-        "arc_home_location_identity": "locations/115340cf-f39e-4d43-a2ee-8017d672c6c6",
-        "arc_display_type": "Traffic light with violation camera",
-        "arc_firmware_version": "1.0",
-        "some_custom_attribute": "value",
-        "arc_attachments": [
-            {
-                "arc_display_name": "arc_primary_image",
-                "arc_attachment_identity": "blobs/87b1a84c-1c6f-442b-923e-a97516f4d275",
-                "arc_hash_alg": "SHA256",
-                "arc_hash_value": "246c316e2cd6971ce5c83a3e61f9880fa6e2f14ae2976ee03500eb282fd03a60"
-            }
-        ]
-    },
-    "confirmation_status": "PENDING",
-    "tracked": "TRACKED"
+    "arc_firmware_version": "3.2.1",
+    "arc_home_location_identity": "locations/42054f10-9952-4c10-a082-9fd0d10295ae"
+  },
+  "behaviours": [
+    "RecordEvidence"
+  ],
+  "confirmation_status": "PENDING",
+  "identity": "assets/add30235-1424-4fda-840a-d5ef82c4c96f",
+  "owner": "0x601f5A7D3e6dcB55e87bf2F17bC8A27AaCD3511",
+  "proof_mechanism": "SIMPLE_HASH",
+  "public": false,
+  "tenant_identity": "tenant/8e0b600c-8234-43e4-860c-e95bdcd695a9",
+  "tracked": "TRACKED"
 }
 ```
+#### Creating a Public Asset
 
+{{< warning >}}
+**Warning**: Assets can only be made public at Asset Creation and cannot be made private afterwards.
+{{< /warning >}}
+
+In most cases it is appropriate to create a standard Asset. These Assets can only be shared externally using Access Policies as described in [Sharing Assets with OBAC](../../quickstart/sharing-assets-with-obac/) or the [IAM Policies API Reference](../iam-policies-api/).
+
+However it is also possible to create a Public Asset which can be shared with a read-only public url; similar to the link sharing you may have seen in file sharing services like Google Drive or DropBox.
+
+Public Assets can be used for Public Attestation, where you may wish to publicly assert data you have published.
+
+For example, the vulnerability reports against an OpenSource software package, or perhaps the maintenance records for a public building.
+
+Creating a Public Asset just requires flipping the `public` value in the above request to `true`, from then on **only** the creating tenancy may update the asset and events on a Public Asset through their private, signed-in interface.
+
+All Public Assets are then given a read-only public URL that can be retrieved using [Fetch a Public Asset's URL](./#fetch-a-public-assets-url), any events added to that Public Asset will also get their own unique Public URL that can be retrieved with [Fetch a Public Asset's Event URL](./#fetch-a-public-assets-event-url).
+
+This link can be shared with anyone to give them read-only access to the asset or event without the need to sign in.
+
+To interact with the unauthenticated Public Interface for a Public Asset see the [Public Assets API Reference](../public-assets-api/). To update the Assets and Events as the creating tenant on a Public Asset's authenticated Private Interface you would still use the standard Assets and Events API as normal.
 ### Asset Record Retrieval
 
 Asset records in RKVST are tokenized at creation time and referred to in all API calls and smart contracts throughout the system by a unique identity of the form:
@@ -171,6 +190,10 @@ curl -g -v -X GET \
 
 Returns all assets which do not have `arc_display_name` or in which `arc_display_name` is empty.
 
+#### Fetch a Public Asset's URL
+
+
+#### Fetch a Public Asset's Event URL
 
 ## Asset OpenAPI Docs
 

--- a/content/docs/api-reference/public-assets-api/index.md
+++ b/content/docs/api-reference/public-assets-api/index.md
@@ -13,6 +13,8 @@ weight: 112
 toc: true
 ---
 
+## Public Assets API Examples
+
 Public Assets are created using the [Assets API](../assets-api/) and setting the value of `public` to `true`.
 
 To see more information about creating a Public Asset see [Creating a Public Asset](../assets-api/#creating-a-public-asset).
@@ -20,9 +22,6 @@ To see more information about creating a Public Asset see [Creating a Public Ass
 Each Public Asset has a Private and a Public Interface, the Private Interface is used to update the asset by the creating tenancy, the Public is a read-only view of the Asset that you do not need to be authenticated for. 
 
 The methods described below cover interacting with the Public Interface Only, to interact with the Private Interface, use the standard [Assets API](../assets-api/). 
-
-## Public Assets API Examples
-
 ### Fetch a Public Asset Record
 
 ```bash

--- a/content/docs/api-reference/public-assets-api/index.md
+++ b/content/docs/api-reference/public-assets-api/index.md
@@ -25,9 +25,180 @@ The methods described below cover interacting with the Public Interface Only, to
 
 ### Fetch a Public Asset Record
 
+```bash
+curl -H "Content-Type: application/json" https://app.rkvst.io/archivist/publicassets/86b61c4b-030e-4c07-9400-463612e6cee4
+```
+
+```json
+{
+  "identity": "assets/86b61c4b-030e-4c07-9400-463612e6cee4",
+  "behaviours": ["RecordEvidence", "Builtin", "AssetCreator"] ,
+  "attributes": {
+    "arc_display_type": "Asset",
+    "foo": "bar",
+    "A": "B",
+    "arc_description": "This asset is public",
+    "arc_display_name": "Public Asset"
+  },
+  "confirmation_status": "CONFIRMED",
+  "tracked": "TRACKED",
+  "owner": "0x5eC362570D1b52a01648997db5ed7693fc6b3978",
+  "at_time": "2022-07-15T14:26:40Z",
+  "storage_integrity": "TENANT_STORAGE",
+  "proof_mechanism": "SIMPLE_HASH",
+  "chain_id": "8275868384",
+  "public": true,
+  "tenant_identity": "tenant/8e0b600c-8234-43e4-860c-e95bdcd695a9"
+}
+```
+
 ### Fetch all of a Public Asset's Events Records
 
+```bash
+curl -H "Content-Type: application/json" https://app.rkvst.io/archivist/publicassets/86b61c4b-030e-4c07-9400-463612e6cee4/events
+```
+
+```json
+{
+    "events": [
+        {
+            "identity": "assets/86b61c4b-030e-4c07-9400-463612e6cee4/events/083f90fb-c379-40db-b56a-190564d53cd5",
+            "asset_identity": "assets/86b61c4b-030e-4c07-9400-463612e6cee4",
+            "event_attributes": {
+                "arc_attachments": [],
+                "arc_display_type": "Change"
+            },
+            "asset_attributes": {
+                "A": "B"
+            },
+            "operation": "Record",
+            "behaviour": "RecordEvidence",
+            "timestamp_declared": "2022-07-06T14:56:24Z",
+            "timestamp_accepted": "2022-07-06T14:56:24Z",
+            "timestamp_committed": "2022-07-06T14:56:24.681514884Z",
+            "principal_declared": {
+                "issuer": "",
+                "subject": "",
+                "display_name": "",
+                "email": ""
+            },
+            "principal_accepted": {
+                "issuer": "",
+                "subject": "",
+                "display_name": "",
+                "email": ""
+            },
+            "confirmation_status": "CONFIRMED",
+            "transaction_id": "",
+            "block_number": 0,
+            "transaction_index": 0,
+            "from": "0x5eC362570D1b52a01648997db5ed7693fc6b3978",
+            "tenant_identity": "tenant/8e0b600c-8234-43e4-860c-e95bdcd695a9"
+        },
+        {
+            "identity": "assets/86b61c4b-030e-4c07-9400-463612e6cee4/events/10d252f2-3116-4c22-b34a-7e3f768895c9",
+            "asset_identity": "assets/86b61c4b-030e-4c07-9400-463612e6cee4",
+            "event_attributes": {
+                "arc_access_policy_always_read": [
+                    {
+                        "tessera": "SmL4PHAHXLdpkj/c6Xs+2br+hxqLmhcRk75Hkj5DyEQ=",
+                        "wallet": "0x5eC362570D1b52a01648997db5ed7693fc6b3978"
+                    }
+                ],
+                "arc_access_policy_asset_attributes_read": [
+                    {
+                        "0x4609ea6bbe85F61bc64760273ce6D89A632B569f": "wallet",
+                        "SmL4PHAHXLdpkj/c6Xs+2br+hxqLmhcRk75Hkj5DyEQ=": "tessera",
+                        "attribute": "*"
+                    }
+                ],
+                "arc_access_policy_event_arc_display_type_read": [
+                    {
+                        "SmL4PHAHXLdpkj/c6Xs+2br+hxqLmhcRk75Hkj5DyEQ=": "tessera",
+                        "value": "*",
+                        "0x4609ea6bbe85F61bc64760273ce6D89A632B569f": "wallet"
+                    }
+                ]
+            },
+            "asset_attributes": {
+                "foo": "bar",
+                "arc_attachments": [],
+                "arc_description": "This asset is public",
+                "arc_display_name": "Public Asset",
+                "arc_display_type": "Asset"
+            },
+            "operation": "NewAsset",
+            "behaviour": "AssetCreator",
+            "timestamp_declared": "2022-07-06T13:38:34Z",
+            "timestamp_accepted": "2022-07-06T13:38:34Z",
+            "timestamp_committed": "2022-07-06T13:38:35.143791572Z",
+            "principal_declared": {
+                "issuer": "",
+                "subject": "",
+                "display_name": "",
+                "email": ""
+            },
+            "principal_accepted": {
+                "issuer": "",
+                "subject": "",
+                "display_name": "",
+                "email": ""
+            },
+            "confirmation_status": "CONFIRMED",
+            "transaction_id": "",
+            "block_number": 0,
+            "transaction_index": 0,
+            "from": "0x5eC362570D1b52a01648997db5ed7693fc6b3978",
+            "tenant_identity": "tenant/8e0b600c-8234-43e4-860c-e95bdcd695a9"
+        }
+    ],
+    "next_page_token": ""
+}
+```
+
+
 ### Fetch a Public Asset's specific Event Record
+
+```bash
+curl -H "Content-Type: application/json" https://app.rkvst.io/archivist/publicassets/86b61c4b-030e-4c07-9400-463612e6cee4/events/7da272ad-19d5-4106-b4af-2980a84c2721
+```
+
+```json
+{
+    "identity": "assets/86b61c4b-030e-4c07-9400-463612e6cee4/events/083f90fb-c379-40db-b56a-190564d53cd5",
+    "asset_identity": "assets/86b61c4b-030e-4c07-9400-463612e6cee4",
+    "event_attributes": {
+        "arc_display_type": "Change",
+        "arc_attachments": []
+    },
+    "asset_attributes": {
+        "A": "B"
+    },
+    "operation": "Record",
+    "behaviour": "RecordEvidence",
+    "timestamp_declared": "2022-07-06T14:56:24Z",
+    "timestamp_accepted": "2022-07-06T14:56:24Z",
+    "timestamp_committed": "2022-07-06T14:56:24.681514884Z",
+    "principal_declared": {
+        "issuer": "",
+        "subject": "",
+        "display_name": "",
+        "email": ""
+    },
+    "principal_accepted": {
+        "issuer": "",
+        "subject": "",
+        "display_name": "",
+        "email": ""
+    },
+    "confirmation_status": "CONFIRMED",
+    "transaction_id": "",
+    "block_number": 0,
+    "transaction_index": 0,
+    "from": "0x5eC362570D1b52a01648997db5ed7693fc6b3978",
+    "tenant_identity": "tenant/8e0b600c-8234-43e4-860c-e95bdcd695a9"
+}
+```
 
 ## Public Assets OpenAPI Docs
 

--- a/content/docs/api-reference/public-assets-api/index.md
+++ b/content/docs/api-reference/public-assets-api/index.md
@@ -1,0 +1,34 @@
+---
+title: "Public Assets API"
+description: "Public Assets API Reference"
+lead: "Public Assets API Reference"
+date: 2021-06-09T11:56:23+01:00
+lastmod: 2021-06-09T11:56:23+01:00
+draft: false
+images: []
+menu: 
+  docs:
+    parent: "api-reference"
+weight: 112
+toc: true
+---
+
+Public Assets are created using the [Assets API](../assets-api/) and setting the value of `public` to `true`.
+
+To see more information about creating a Public Asset see [Creating a Public Asset](../assets-api/#creating-a-public-asset).
+
+Each Public Asset has a Private and a Public Interface, the Private Interface is used to update the asset by the creating tenancy, the Public is a read-only view of the Asset that you do not need to be authenticated for. 
+
+The methods described below cover interacting with the Public Interface Only, to interact with the Private Interface, use the standard [Assets API](../assets-api/). 
+
+## Public Assets API Examples
+
+### Fetch a Public Asset Record
+
+### Fetch all of a Public Asset's Events Records
+
+### Fetch a Public Asset's specific Event Record
+
+## Public Assets OpenAPI Docs
+
+{{< openapi url="https://raw.githubusercontent.com/jitsuin-inc/archivist-docs/master/doc/openapi/publicassetsv2.swagger.json" >}}

--- a/content/docs/api-reference/tenancies-api/index.md
+++ b/content/docs/api-reference/tenancies-api/index.md
@@ -9,7 +9,7 @@ images: []
 menu: 
   docs:
     parent: "api-reference"
-weight: 113
+weight: 114
 toc: true
 ---
 

--- a/content/docs/api-reference/tls-ca-certificates-api/index.md
+++ b/content/docs/api-reference/tls-ca-certificates-api/index.md
@@ -9,7 +9,7 @@ images: []
 menu: 
   docs:
     parent: "api-reference"
-weight: 114
+weight: 115
 toc: true
 ---
 


### PR DESCRIPTION
Added most of the explaining sections which need a review, also need someone from Engineering to update the following curl examples

In Assets API:

* Fetching a Public Asset's URL
* Fetching a Public Asset's Event URL

In Public Assets API

* Fetch a Public Asset Record
* Fetch all of a Public Asset's Events Records
* Fetch a Public Asset's specific Event Record