### PR TITLE
Adding note about ABAC vs OBAC to API docs

### DIFF
--- a/content/docs/api-reference/app-registrations-api/index.md
+++ b/content/docs/api-reference/app-registrations-api/index.md
@@ -19,6 +19,8 @@ The App Registrations API enables you to create and manage application identitie
 
 It supports the OpenID Connect Client Credentials Flow, which means that for each application you register, a `CLIENT_ID` and `SECRET` are generated and returned. 
 
+Each App Registration is created with non-root privileges by default; you must create an [ABAC policy](../iam-policies-api/) to permit specific access to that App Registration. It is also possible to give these credentials Root User Access, but it is considered best practice to create specific ABAC policies, preserving Principle of Least Privilege, instead.
+
 These can be used to request an access token from `https://app.rkvst.io/archivist/iam/v1/appidp/token`, used for application authentication to RKVST.
 
 ### Creating an Application

--- a/content/docs/api-reference/app-registrations-api/index.md
+++ b/content/docs/api-reference/app-registrations-api/index.md
@@ -23,9 +23,9 @@ These credentials are then used to request an access token from `https://app.rkv
 
 Each App Registration is created with non-root privileges by default.
 
-To provide your credentials with access to the Assets and Events in your Tenancy it is best practice to create an [ABAC policy](../iam-policies-api/) with specific, declared permissions. 
+To provide your credentials with access to the Assets and Events in your Tenancy, it is best practice to create an [ABAC policy](../iam-policies-api/) with specific, declared permissions. 
 
-If you did wish to give your credentials root user priviliges to access everything in your tenancy you would use the `client-id` as the subject and `https://app.rkvst.io/appidpv1` as the issuer in either the `Manage RKVST` screen, or by using the [Root Users Endpoint in the Tenancies API](../tenancies-api/).
+If you wish to give your credentials root user priviliges to access everything in your tenancy, you would use the `client-id` as the subject and `https://app.rkvst.io/appidpv1` as the issuer in either the `Manage RKVST` screen, or by using the [Root Users Endpoint in the Tenancies API](../tenancies-api/).
 ### Creating an Application
 
 Create a JSON file with the parameters of your new application. Below is an example:

--- a/content/docs/api-reference/app-registrations-api/index.md
+++ b/content/docs/api-reference/app-registrations-api/index.md
@@ -17,12 +17,15 @@ toc: true
 
 The App Registrations API enables you to create and manage application identities with access to your RKVST tenant. 
 
-It supports the OpenID Connect Client Credentials Flow, which means that for each application you register, a `CLIENT_ID` and `SECRET` are generated and returned. 
+It supports the OpenID Connect Client Credentials Flow, which means that for each application you register, a `CLIENT_ID` and `SECRET` are generated and returned.
 
-Each App Registration is created with non-root privileges by default; you must create an [ABAC policy](../iam-policies-api/) to permit specific access to that App Registration. It is also possible to give these credentials Root User Access, but it is considered best practice to create specific ABAC policies, preserving Principle of Least Privilege, instead.
+These credentials are then used to request an access token from `https://app.rkvst.io/archivist/iam/v1/appidp/token`, which is used for API authentication to RKVST.
 
-These can be used to request an access token from `https://app.rkvst.io/archivist/iam/v1/appidp/token`, used for application authentication to RKVST.
+Each App Registration is created with non-root privileges by default.
 
+To provide your credentials with access to the Assets and Events in your Tenancy it is best practice to create an [ABAC policy](../iam-policies-api/) with specific, declared permissions. 
+
+If you did wish to give your credentials root user priviliges to access everything in your tenancy you would use the `client-id` as the subject and `https://app.rkvst.io/appidpv1` as the issuer in either the `Manage RKVST` screen, or by using the [Root Users Endpoint in the Tenancies API](../tenancies-api/).
 ### Creating an Application
 
 Create a JSON file with the parameters of your new application. Below is an example:

--- a/content/docs/api-reference/iam-policies-api/index.md
+++ b/content/docs/api-reference/iam-policies-api/index.md
@@ -19,6 +19,16 @@ Create the [bearer_token](../../setup-and-administration/getting-access-tokens-u
 
 ### IAM Policy Creation
 
+Access Policies may be used to grant permissions within your tenancy or to external organizations. This is referred to as [ABAC](https://docs.rkvst.com/docs/quickstart/managing-access-to-an-asset-with-abac/) and [OBAC](https://docs.rkvst.com/docs/quickstart/sharing-assets-with-obac/), respectively. 
+
+An ABAC policy uses email addresses to share with non-root users within your tenancy. ABAC policies may also be used to grant permissions to App Registrations, identified by their Client ID. 
+
+Each App Registration is created with non-root privileges by default; you must create an ABAC policy to permit specific access to that App Registration like you would for any other non-root user.
+
+It is also possible to give these credentials Root User Access, but it is considered best practice to create specific ABAC policies preserving Principle of Least Privilege instead.
+
+To create an OBAC policy, you will first need to retrieve their Subject ID using the [IAM Subjects API](https://docs.rkvst.com/docs/api-reference/iam-subjects-api/). 
+
 Define the access_policies parameters and store in `/path/to/jsonfile`:
 
 ```json

--- a/content/docs/api-reference/iam-policies-api/index.md
+++ b/content/docs/api-reference/iam-policies-api/index.md
@@ -23,9 +23,9 @@ Access Policies may be used to grant permissions within your tenancy or to exter
 
 An ABAC policy uses email addresses to share with non-root users within your tenancy. ABAC policies may also be used to grant permissions to App Registrations, identified by their Client ID. 
 
-Each App Registration is created with non-root privileges by default; you must create an ABAC policy to permit specific access to that App Registration like you would for any other non-root user.
+Each App Registration is created with non-root privileges by default; you must create an ABAC policy to permit specific access to that App Registration, like you would for any other non-root user.
 
-It is also possible to give these credentials Root User Access, but it is considered best practice to create specific ABAC policies preserving Principle of Least Privilege instead.
+It is also possible to give these credentials Root User Access, but it is considered best practice to create specific ABAC policies, preserving Principle of Least Privilege, instead.
 
 To create an OBAC policy, you will first need to retrieve their Subject ID using the [IAM Subjects API](https://docs.rkvst.com/docs/api-reference/iam-subjects-api/). 
 

--- a/content/docs/api-reference/iam-policies-api/index.md
+++ b/content/docs/api-reference/iam-policies-api/index.md
@@ -17,9 +17,9 @@ toc: true
 
 Create the [bearer_token](../../setup-and-administration/getting-access-tokens-using-app-registrations) and store in a file in a secure local directory with 0600 permissions.
 
-An [ABAC](https://docs.rkvst.com/docs/quickstart/managing-access-to-an-asset-with-abac/) policy is used to share permissions with non-root users within your tenancy. A non-root user could be a user who has been added using the [Invites API](../invites-api/) or could be an App Registration used for client credentials. which are created as non-root by default.
+An [ABAC](https://docs.rkvst.com/docs/quickstart/managing-access-to-an-asset-with-abac/) policy is used to share permissions with non-root users within your tenancy. A non-root user could be a user who has been added using the [Invites API](../invites-api/) or could be an App Registration used for client credentials, which are created as non-root by default.
 
-To create an ABAC Policy you should use the `user_attributes` keyword and then specify `email` for invited users, and `subject`, using the client-id of your credentials for App Registrations.
+To create an ABAC Policy you should use the `user_attributes` keyword. Specify `email` for invited users, and `subject`, using the client-id of your credentials, for App Registrations.
 
 An [OBAC](https://docs.rkvst.com/docs/quickstart/sharing-assets-with-obac/) policy is used to share with the root users of an external organization. 
 
@@ -27,7 +27,8 @@ To create an OBAC policy, you will first need to retrieve their Subject ID using
 
 You would then use the `subjects` keyword and specify the Subject ID that you imported earlier.
 
-Once you know who you are sharing with the policy syntax should be similar.
+Once you know who you are sharing with, the policy syntax should be similar.
+
 ### IAM Policy Creation
 
 Define the access_policies parameters and store in `/path/to/jsonfile`:

--- a/content/docs/api-reference/iam-policies-api/index.md
+++ b/content/docs/api-reference/iam-policies-api/index.md
@@ -19,7 +19,7 @@ Create the [bearer_token](../../setup-and-administration/getting-access-tokens-u
 
 An [ABAC](https://docs.rkvst.com/docs/quickstart/managing-access-to-an-asset-with-abac/) policy is used to share permissions with non-root users within your tenancy. A non-root user could be a user who has been added using the [Invites API](../invites-api/) or could be an App Registration used for client credentials, which are created as non-root by default.
 
-To create an ABAC Policy you should use the `user_attributes` keyword. Specify `email` for invited users, and `subject`, using the client-id of your credentials, for App Registrations.
+To create an ABAC Policy, you should use the `user_attributes` keyword. Specify `email` for invited users, and `subject`, using the client-id of your credentials, for App Registrations.
 
 An [OBAC](https://docs.rkvst.com/docs/quickstart/sharing-assets-with-obac/) policy is used to share with the root users of an external organization. 
 

--- a/content/docs/api-reference/iam-policies-api/index.md
+++ b/content/docs/api-reference/iam-policies-api/index.md
@@ -17,17 +17,18 @@ toc: true
 
 Create the [bearer_token](../../setup-and-administration/getting-access-tokens-using-app-registrations) and store in a file in a secure local directory with 0600 permissions.
 
+An [ABAC](https://docs.rkvst.com/docs/quickstart/managing-access-to-an-asset-with-abac/) policy is used to share permissions with non-root users within your tenancy. A non-root user could be a user who has been added using the [Invites API](../invites-api/) or could be an App Registration used for client credentials. which are created as non-root by default.
+
+To create an ABAC Policy you should use the `user_attributes` keyword and then specify `email` for invited users, and `subject`, using the client-id of your credentials for App Registrations.
+
+An [OBAC](https://docs.rkvst.com/docs/quickstart/sharing-assets-with-obac/) policy is used to share with the root users of an external organization. 
+
+To create an OBAC policy, you will first need to retrieve their Subject ID using the [IAM Subjects API](https://docs.rkvst.com/docs/api-reference/iam-subjects-api/) and import it.
+
+You would then use the `subjects` keyword and specify the Subject ID that you imported earlier.
+
+Once you know who you are sharing with the policy syntax should be similar.
 ### IAM Policy Creation
-
-Access Policies may be used to grant permissions within your tenancy or to external organizations. This is referred to as [ABAC](https://docs.rkvst.com/docs/quickstart/managing-access-to-an-asset-with-abac/) and [OBAC](https://docs.rkvst.com/docs/quickstart/sharing-assets-with-obac/), respectively. 
-
-An ABAC policy uses email addresses to share with non-root users within your tenancy. ABAC policies may also be used to grant permissions to App Registrations, identified by their Client ID. 
-
-Each App Registration is created with non-root privileges by default; you must create an ABAC policy to permit specific access to that App Registration, like you would for any other non-root user.
-
-It is also possible to give these credentials Root User Access, but it is considered best practice to create specific ABAC policies, preserving Principle of Least Privilege, instead.
-
-To create an OBAC policy, you will first need to retrieve their Subject ID using the [IAM Subjects API](https://docs.rkvst.com/docs/api-reference/iam-subjects-api/). 
 
 Define the access_policies parameters and store in `/path/to/jsonfile`:
 

--- a/content/docs/api-reference/iam-policies-api/index.md
+++ b/content/docs/api-reference/iam-policies-api/index.md
@@ -21,15 +21,17 @@ An [ABAC](https://docs.rkvst.com/docs/quickstart/managing-access-to-an-asset-wit
 
 To create an ABAC Policy, you should use the `user_attributes` keyword. Specify `email` for invited users, and `subject`, using the client-id of your credentials, for App Registrations.
 
-An [OBAC](https://docs.rkvst.com/docs/quickstart/sharing-assets-with-obac/) policy is used to share with the root users of an external organization. 
+An [OBAC](https://docs.rkvst.com/docs/quickstart/sharing-assets-with-obac/) policy is used to share with the root users of an external organization.
 
-To create an OBAC policy, you will first need to retrieve their Subject ID using the [IAM Subjects API](https://docs.rkvst.com/docs/api-reference/iam-subjects-api/) and import it.
+To begin sharing with OBAC you must first import your collaborator's Organization ID using either the [IAM Subjects API](../iam-subjects-api/) or the instructions in the [basics section](../../quickstart/sharing-assets-with-obac/#importing-another-organizations-ids).
 
-You would then use the `subjects` keyword and specify the Subject ID that you imported earlier.
+This will return a `subjects/<UUID>` object you would then specify with the `subjects` keyword to make it an OBAC policy.
 
-Once you know who you are sharing with, the policy syntax should be similar.
+As both ABAC and OBAC use the same filter syntax it is possible to have a mix of internal and external sharing within a single policy.
 
 ### IAM Policy Creation
+
+The following example shows how you can mix the `user_attributes` keyword for ABAC and `subjects` keyword for OBAC.
 
 Define the access_policies parameters and store in `/path/to/jsonfile`:
 


### PR DESCRIPTION
Specifying types of policies and their respective user identifiers. Phrasing may need reworking and examples might be needed. 