### PR TITLE
arc_correlation_id to arc_correlation_value

### DIFF
--- a/content/docs/api-reference/compliance-api/index.md
+++ b/content/docs/api-reference/compliance-api/index.md
@@ -59,7 +59,7 @@ For example “Time since last Maintenance must be less than 72 hours”:
 
 This Compliance Policy will only pass if there is an associated answering event addressing a specified outstanding event.
 
-To correlate events define the attribute `arc_correlation_id` in the Event Attributes and set it to the same value on each pair of events that are to be associated. 
+To correlate events define the attribute `arc_correlation_value` in the Event Attributes and set it to the same value on each pair of events that are to be associated. 
 
 For example defining pairs of Events like `Maintenance Request` and `Maintenance Performed`: 
 
@@ -87,7 +87,7 @@ For example defining pairs of Events like `Maintenance Request` and `Maintenance
 
 This Compliance Policy will only pass if the time between a pair of correlated events did not exceed the defined threshold. 
 
-To correlate events define the attribute `arc_correlation_id` in the Event Attributes and set it to the same value on each pair of events that are to be associated. 
+To correlate events define the attribute `arc_correlation_value` in the Event Attributes and set it to the same value on each pair of events that are to be associated. 
 
 For example, a policy checking that the time between `Maintenance Request` and `Maintenance Performed` Events does not exceed the maximum 72 hours:
 ```json
@@ -116,7 +116,7 @@ For example, a policy checking that the time between `Maintenance Request` and `
 
 This Compliance Policy will only pass if the time between a pair of correlated events did not exceed the defined variability. 
 
-To correlate events define the attribute `arc_correlation_id` in the Event Attributes and set it to the same value on each pair of events that are to be associated. 
+To correlate events define the attribute `arc_correlation_value` in the Event Attributes and set it to the same value on each pair of events that are to be associated. 
 
 For example, a policy checking that the time between `Maintenance Request` and `Maintenance Performed` Events in the last week does not exceed a variability of 0.5 standard deviations around the mean:
 

--- a/content/docs/overview/advanced-concepts/index.md
+++ b/content/docs/overview/advanced-concepts/index.md
@@ -344,7 +344,7 @@ As with Assets and Events, Compliance Policies are very flexible and can be conf
 * *COMPLIANCE_DYNAMIC_TOLERANCE*: This Compliance Policy will only pass if the time between a pair of correlated events or the value of an attribute does not exceed the a variability from the usually observed values.<br><br>For example, a policy checking that maintenance times are not considerably longer than normal, or the weight of a container is not much less than the typical average.
 
 {{< note >}}
-**Note:** To correlate events define the attribute `arc_correlation_id` in the Event Attributes and set it to the same value on each pair of events that are to be associated.
+**Note:** To correlate events define the attribute `arc_correlation_value` in the Event Attributes and set it to the same value on each pair of events that are to be associated.
 {{< /note >}}
 
 ## Perspectives 


### PR DESCRIPTION
Changing incorrect 'arc_correlation_id' to correct 'arc_correlation_value' in Advanced Concepts section. 