### PR TITLE
Adding Quotes Around URLs with Query Strings

### DIFF
--- a/content/docs/api-reference/assets-api/index.md
+++ b/content/docs/api-reference/assets-api/index.md
@@ -141,7 +141,7 @@ If you know the unique identity of an Asset Record and want to show its state at
 ```bash
 curl -v -X GET \
      -H "@$BEARER_TOKEN_FILE" \
-     https://app.rkvst.io/archivist/v2/assets/6a951b62-0a26-4c22-a886-1082297b063b?at_time=2021-01-13T12:34:21Z
+     "https://app.rkvst.io/archivist/v2/assets/6a951b62-0a26-4c22-a886-1082297b063b?at_time=2021-01-13T12:34:21Z"
 ```
 
 This will return the Asset Record with the values it had on `2021-01-13T12:34:21Z`
@@ -153,7 +153,7 @@ To fetch all assets with a specific name, GET the assets resource and filter on 
 ```bash
 curl -g -v -X GET \
      -H "@$BEARER_TOKEN_FILE" \
-     https://app.rkvst.io/archivist/v2/assets?attributes.arc_display_name=tcl.ccj.003
+     "https://app.rkvst.io/archivist/v2/assets?attributes.arc_display_name=tcl.ccj.003"
 ```
 
 #### Fetch Assets by Type
@@ -163,7 +163,7 @@ To fetch all assets of a specific type, `GET` the assets resource and filter on 
 ```bash
 curl -g -v -X GET \
      -H "@$BEARER_TOKEN_FILE" \
-     https://app.rkvst.io/archivist/v2/assets?attributes.arc_display_type=Traffic%20light
+     "https://app.rkvst.io/archivist/v2/assets?attributes.arc_display_type=Traffic%20light"
 ```
 
 #### Fetch Assets by Filtering for Presence of a Field
@@ -173,7 +173,7 @@ To fetch all assets with a field set to any value, `GET` the assets resource and
 ```bash
 curl -g -v -X GET \
      -H "@$BEARER_TOKEN_FILE" \
-     https://app.rkvst.io/archivist/v2/assets?attributes.arc_display_name=*
+     "https://app.rkvst.io/archivist/v2/assets?attributes.arc_display_name=*"
 ```
 
 Returns all assets which have `arc_display_name` that is not empty.
@@ -185,7 +185,7 @@ To fetch all assets with a field which is not set to any value, `GET` the assets
 ```bash
 curl -g -v -X GET \
      -H "@$BEARER_TOKEN_FILE" \
-     https://app.rkvst.io/archivist/v2/assets?attributes.arc_display_name!=*
+     "https://app.rkvst.io/archivist/v2/assets?attributes.arc_display_name!=*"
 ```
 
 Returns all assets which do not have `arc_display_name` or in which `arc_display_name` is empty.

--- a/content/docs/api-reference/compliance-api/index.md
+++ b/content/docs/api-reference/compliance-api/index.md
@@ -230,7 +230,7 @@ or if determining compliance at some historical date:
 ```bash
 curl -v -X GET \
     -H "@$BEARER_TOKEN_FILE" \
-    https://app.rkvst.io/archivist/v1/compliance/assets/6a951b62-0a26-4c22-a886-1082297b063b?compliant_at=2019-11-27T14:44:19Z
+    "https://app.rkvst.io/archivist/v1/compliance/assets/6a951b62-0a26-4c22-a886-1082297b063b?compliant_at=2019-11-27T14:44:19Z"
 ```
 The response is:
 

--- a/content/docs/api-reference/iam-policies-api/index.md
+++ b/content/docs/api-reference/iam-policies-api/index.md
@@ -157,7 +157,7 @@ To fetch all IAM `access_policies` with a specific name, `GET` the `iam/access_p
 ```bash
 curl -g -v -X GET \
      -H "@$BEARER_TOKEN_FILE" \
-     https://app.rkvst.io/archivist/iam/v1/access_policies?display_name=Some%20description
+     "https://app.rkvst.io/archivist/iam/v1/access_policies?display_name=Some%20description"
 ```
 Each of these calls returns a list of matching IAM access_policies records in the form:
 

--- a/content/docs/api-reference/iam-subjects-api/index.md
+++ b/content/docs/api-reference/iam-subjects-api/index.md
@@ -88,7 +88,7 @@ To fetch all IAM subjects with a specific name, `GET` the `/subjects` resource a
 ```bash
 curl -g -v -X GET \
      -H "@$BEARER_TOKEN_FILE" \
-     https://app.rkvst.io/archivist/iam/v1/subjects?display_name=Acme
+     "https://app.rkvst.io/archivist/iam/v1/subjects?display_name=Acme"
 ```
 
 Each of these calls returns a list of matching IAM subjects records in the form:

--- a/content/docs/api-reference/locations-api/index.md
+++ b/content/docs/api-reference/locations-api/index.md
@@ -95,7 +95,7 @@ To fetch all locations with a specific name, `GET` the assets resource and filte
 ```bash
 curl -v -X GET \
     -H "@$BEARER_TOKEN_FILE" \
-    https://app.rkvst.io/archivist/v2/locations?display_name=Macclesfield%2C%20Cheshire
+    "https://app.rkvst.io/archivist/v2/locations?display_name=Macclesfield%2C%20Cheshire"
 ```
 
 Each of these calls returns a list of matching asset records in the form:

--- a/content/docs/api-reference/tls-ca-certificates-api/index.md
+++ b/content/docs/api-reference/tls-ca-certificates-api/index.md
@@ -95,7 +95,7 @@ To fetch all TLS CA Certificates with a specific name, `GET` the `tlscacertifica
 ```bash
 curl -g -v -X GET \
      -H "@$BEARER_TOKEN_FILE" \
-     https://app.rkvst.io/archivist/v1/tlscacertificates?display_name=Acme
+     "https://app.rkvst.io/archivist/v1/tlscacertificates?display_name=Acme"
 ```
 
 Each of these calls returns a list of matching TLS CA Certificate records in the form (certificate field shortened for brevity):


### PR DESCRIPTION
Quotes added around URLs with queries so bash doesn't misinterpret the URL when curl commands are used. Otherwise, '?' within string gets misinterpreted and the error 'zsh: no matches found' is displayed. 