### PR TITLE
adding jwt claim info to ABAC

### DIFF
--- a/content/docs/api-reference/iam-policies-api/index.md
+++ b/content/docs/api-reference/iam-policies-api/index.md
@@ -19,7 +19,9 @@ Create the [bearer_token](../../setup-and-administration/getting-access-tokens-u
 
 An [ABAC](https://docs.rkvst.com/docs/quickstart/managing-access-to-an-asset-with-abac/) policy is used to share permissions with non-root users within your tenancy. A non-root user could be a user who has been added using the [Invites API](../invites-api/) or could be an App Registration used for client credentials, which are created as non-root by default.
 
-To create an ABAC Policy, you should use the `user_attributes` keyword. Specify `email` for invited users, and `subject`, using the client-id of your credentials, for App Registrations. You may also set permissions based on JSON Web Tokens (JWTs). To do so, you must include the prefix `jwt_` followed by the desired claim. For example, the key `jwt_foo` to match on claim `foo`.
+To create an ABAC Policy, you should use the `user_attributes` keyword. Specify `email` for invited users, and `subject`, using the client-id of your credentials, for App Registrations. 
+
+You may also set permissions based on the Custom Claims of an [App Registration](https://docs.rkvst.com/docs/rkvst-basics/getting-access-tokens-using-app-registrations/) using JSON Web Tokens (JWTs). To do so, you must include the prefix `jwt_` followed by the desired claim as one of the `user_attributes` in the policy. For example, the key `jwt_app_reg_role` to match on claim `app_reg_role`.
 
 An [OBAC](https://docs.rkvst.com/docs/quickstart/sharing-assets-with-obac/) policy is used to share with the root users of an external organization.
 

--- a/content/docs/api-reference/iam-policies-api/index.md
+++ b/content/docs/api-reference/iam-policies-api/index.md
@@ -19,7 +19,7 @@ Create the [bearer_token](../../setup-and-administration/getting-access-tokens-u
 
 An [ABAC](https://docs.rkvst.com/docs/quickstart/managing-access-to-an-asset-with-abac/) policy is used to share permissions with non-root users within your tenancy. A non-root user could be a user who has been added using the [Invites API](../invites-api/) or could be an App Registration used for client credentials, which are created as non-root by default.
 
-To create an ABAC Policy, you should use the `user_attributes` keyword. Specify `email` for invited users, and `subject`, using the client-id of your credentials, for App Registrations.
+To create an ABAC Policy, you should use the `user_attributes` keyword. Specify `email` for invited users, and `subject`, using the client-id of your credentials, for App Registrations. You may also set permissions based on JSON Web Tokens (JWTs). To do so, you must include the prefix `jwt_` followed by the desired claim. For example, the key `jwt_foo` to match on claim `foo`.
 
 An [OBAC](https://docs.rkvst.com/docs/quickstart/sharing-assets-with-obac/) policy is used to share with the root users of an external organization.
 

--- a/content/docs/rkvst-basics/getting-access-tokens-using-app-registrations/index.md
+++ b/content/docs/rkvst-basics/getting-access-tokens-using-app-registrations/index.md
@@ -46,7 +46,7 @@ When enabling non-interactive access to RKVST, you ***must*** create your first 
 3. Enter any display name you like and then click `CREATE APP REGISTRATION`.
 
 {{< note >}}
- You can optionally add any Custom Claims at this step, you must ensure they do not start with `jit_` or use of the [well-known reserved claims](https://auth0.com/docs/security/tokens/json-web-tokens/json-web-token-claims#reserved-claims).
+ You can optionally add any Custom Claims at this step. You must ensure they do not start with `jit_` or use any of the [well-known reserved claims](https://auth0.com/docs/security/tokens/json-web-tokens/json-web-token-claims#reserved-claims). The Custom Claims can be used in an [Attribute-Based Access Control (ABAC) policy](../managing-access-to-an-asset-with-abac/) to grant permissions. 
 {{< /note >}}
 
 {{< img src="CreateAppRegistration.png" alt="Rectangle" caption="<em>Completed Web Registration</em>" class="border-0" >}}

--- a/content/docs/rkvst-basics/managing-access-to-an-asset-with-abac/index.md
+++ b/content/docs/rkvst-basics/managing-access-to-an-asset-with-abac/index.md
@@ -122,7 +122,7 @@ There are a few ways you may add a `User` to your Access Policy using JSON. One 
         }
     ]
 ```
-You may also grant permissions to an [App Registration](https://docs.rkvst.com/docs/setup-and-administration/getting-access-tokens-using-app-registrations/) within your tenancy. App Registrations are non-root by default; best practice is to use ABAC policies to preserve Principle of Least Privilege.  
+You may also grant permissions to an [App Registration](https://docs.rkvst.com/docs/rkvst-basics/getting-access-tokens-using-app-registrations/) within your tenancy. App Registrations are non-root by default; best practice is to use ABAC policies to preserve Principle of Least Privilege.  
 
 ```json
  "access_permissions": [
@@ -138,14 +138,14 @@ You may also grant permissions to an [App Registration](https://docs.rkvst.com/d
 **Note:** This is different from adding `subjects` as a key in your `access_permissions`, for example, when adding an external Subject ID to an OBAC policy. The user attribute `subject` refers to the Client ID associated with an App Registration.
 {{< /note >}}
 
-Additionally, you may set permissions based on JSON Web Tokens (JWTs). To do so, you must include the prefix `jwt_` followed by the desired claim. For example, the `user_attributes` should contain the key `jwt_foo` to match on claim `foo`.
+Additionally, you may set permissions based on the Custom Claims of an [App Registration](https://docs.rkvst.com/docs/rkvst-basics/getting-access-tokens-using-app-registrations/) using JSON Web Tokens (JWTs). To do so, you must include the prefix `jwt_` followed by the desired claim as one of the `user_attributes` in the policy. For example, the key `jwt_app_reg_role` to match on claim `app_reg_role`.
 
  ```json
   "access_permissions": [
          {
              "asset_attributes_read": ["arc_display_name", "arc_description", "arc_home_location_identity", "Length", "Weight"],
              "user_attributes": [
-                {"or": ["jwt_foo=4e28571b-6bb5-45a5-97e1-b1ab8a71acb7-app1"]}
+                {"or": ["jwt_app_reg_role=tracker"]}
              ]
          }
      ]

--- a/content/docs/rkvst-basics/managing-access-to-an-asset-with-abac/index.md
+++ b/content/docs/rkvst-basics/managing-access-to-an-asset-with-abac/index.md
@@ -138,6 +138,20 @@ You may also grant permissions to an [App Registration](https://docs.rkvst.com/d
 **Note:** This is different from adding `subjects` as a key in your `access_permissions`, for example, when adding an external Subject ID to an OBAC policy. The user attribute `subject` refers to the Client ID associated with an App Registration.
 {{< /note >}}
 
+Additionally, you may set permissions based on JSON Web Tokens (JWTs). To do so, you must include the prefix `jwt_` followed by the desired claim. For example, the `user_attributes` should contain the key `jwt_foo` to match on claim `foo`.
+
+ ```json
+  "access_permissions": [
+         {
+             "asset_attributes_read": ["arc_display_name", "arc_description", "arc_home_location_identity", "Length", "Weight"],
+             "user_attributes": [
+                {"or": ["jwt_foo=4e28571b-6bb5-45a5-97e1-b1ab8a71acb7-app1"]}
+             ]
+         }
+     ]
+ ```
+
+
 {{< /tab >}}}
 {{< /tabs >}}
 


### PR DESCRIPTION
Added instructions for using the 'jwt_' prefix to match on a json web token claim when granting permissions using ABAC.