### PR TITLE
Note About Accepting Subject Import

### DIFF
--- a/content/docs/api-reference/iam-policies-api/index.md
+++ b/content/docs/api-reference/iam-policies-api/index.md
@@ -29,6 +29,10 @@ To begin sharing with OBAC you must first import your collaborator's Organizatio
 
 This will return a `subjects/<UUID>` object you would then specify with the `subjects` keyword to make it an OBAC policy.
 
+{{< note >}}
+**Note:** To accept a subject import request, both organizations must have imported the other's Subject ID. This acknowledges that the organizations wish to share with each other.
+{{< /note >}}
+
 As both ABAC and OBAC use the same filter syntax it is possible to have a mix of internal and external sharing within a single policy.
 
 ### IAM Policy Creation

--- a/content/docs/rkvst-basics/sharing-assets-with-obac/index.md
+++ b/content/docs/rkvst-basics/sharing-assets-with-obac/index.md
@@ -93,6 +93,10 @@ curl -v -X POST \
 {{< /tab >}}}
 {{< /tabs >}}
 
+{{< note >}}
+**Note:** To accept a subject import request, both organizations must have imported the other's Subject ID. This acknowledges that the organizations wish to share with each other. Once both organizations have accepted, there will be a blue checkmark next to their subject name. 
+{{< /note >}}
+
 ## Creating an OBAC Policy
 
 OBAC creation uses many of the same steps, filters, controls, and forms as ABAC Policies.


### PR DESCRIPTION
Added note to OBAC section of RKVST Basics and IAM Policies API Ref to clarify that both organizations must import the other's Subject ID to accept the subject import request and begin sharing. 