### PR TITLE
Add CSP headers for GitHub Pages prod

### DIFF
--- a/layouts/partials/head/head.html
+++ b/layouts/partials/head/head.html
@@ -2,6 +2,7 @@
   <meta charset="utf-8">
   <meta http-equiv="x-ua-compatible" content="ie=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+  <meta http-equiv="Content-Security-Policy" content="script-src 'self' 'sha256-eg7hiIPJDJy7WtCOgK4mlnMdUDYpX6h90ef9pORicds=' https://www.googletagmanager.com/gtag/js js.hs-scripts.com https://js.hscollectedforms.net/collectedforms.js js.hs-analytics.net https://js.usemessages.com/conversations-embed.js https://js.hsadspixel.net/fb.js js.hs-banner.com https://www.google-analytics.com/analytics.js googleads.g.doubleclick.net;">
   {{ block "head/resource-hints" . }}{{ partial "head/resource-hints.html" . }}{{ end }}
   {{ block "head/stylesheet" . }}{{ partial "head/stylesheet.html" . }}{{ end }}
   {{ block "head/seo" . }}{{ partial "head/seo.html" . }}{{ end }}


### PR DESCRIPTION
The earlier fix worked for local builds but GitHub Pages doesn't accept HTTP header configuration so we need to put it in the HTML instead.